### PR TITLE
fix(gtk): force Cairo renderer; bump version to 1.6.1

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ==================== ADGUARD VPN GUI ====================
-# ВЕРСИЯ: 1.6.0 (фиксированная структура интерфейса)
+# ВЕРСИЯ: 1.6.1 (фиксированная структура интерфейса)
 # БЛОК ИМПОРТОВ
 import gi
 import sys
@@ -13,12 +13,16 @@ import select
 import time
 from getpass import getuser
 
+# Принудительно используем Cairo-рендерер для GTK4 в окружениях без GL (headless/VM/SSH)
+if "GSK_RENDERER" not in os.environ:
+    os.environ["GSK_RENDERER"] = "cairo"
+
 gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, GLib
 
 # ==================== КОНФИГУРАЦИЯ ====================
-VERSION = "1.6.0"
+VERSION = "1.6.1"
 APP_ID = "com.example.AdGuardVPN"
 ADGUARD_PATH = "/opt/adguardvpn_cli/adguardvpn-cli"
 CURRENT_USER = getuser()


### PR DESCRIPTION
This PR forces GTK4 to use the Cairo renderer in environments without an OpenGL context to prevent the warning: \n\n  gdk_gl_context_make_current() failed\n\nChanges:\n- Set `GSK_RENDERER=cairo` in code before GTK imports when not already set.\n- Bump app version to 1.6.1.\n\nValidation:\n- Git sync OK\n- Python syntax check: `python3 -m py_compile test.py` succeeded.\n\nDroid-assisted.